### PR TITLE
ff fixes

### DIFF
--- a/gold-cc-input.html
+++ b/gold-cc-input.html
@@ -63,6 +63,7 @@ Example:
             required$="[[required]]"
             allowed-pattern="[0-9]"
             prevent-invalid-input
+            autocomplete$="[[autocomplete]]"
             name$="[[name]]">
         <div class="icon-container"><iron-icon id="icon"></iron-icon></div>
       </div>


### PR DESCRIPTION
This fixes:

- inputs have a min width in Firefox, which means the icon could get pushed out
- NVDA on Firefox reads "autocomplete" if the attribute isn't set