### PR TITLE
add autocomplete field

### DIFF
--- a/gold-cc-input.html
+++ b/gold-cc-input.html
@@ -87,7 +87,7 @@ style this element.
             required$="[[required]]"
             allowed-pattern="[0-9]"
             prevent-invalid-input
-            autocomplete$="[[autocomplete]]"
+            autocomplete="cc-number"
             name$="[[name]]">
         <div class="icon-container"><iron-icon id="icon"></iron-icon></div>
       </div>


### PR DESCRIPTION
Apparently the `autocomplete` field has meaning. See: https://developers.google.com/web/fundamentals/input/form/label-and-name-inputs?hl=en

It worked by magic in some of the elements because they had a heuristic-approved name in the demo, but now it works regardless of the name.

It's kind of neat for credit cards, which don't autocomplete on crappy connections:
![screen shot 2015-05-28 at 4 57 32 pm](https://cloud.githubusercontent.com/assets/1369170/7873808/da81a3ea-055b-11e5-8974-6656fc588a27.png)

/cc @morethanreal @cdata 
