### PR TITLE
preserve caret position when editing

### DIFF
--- a/gold-cc-input.html
+++ b/gold-cc-input.html
@@ -85,7 +85,7 @@ style this element.
             type="tel"
             maxlength="30"
             required$="[[required]]"
-            allowed-pattern="[0-9]"
+            allowed-pattern="[0-9 ]"
             prevent-invalid-input
             autocomplete="cc-number"
             name$="[[name]]">
@@ -150,13 +150,20 @@ style this element.
       }
       this.value = formattedValue.trim();
 
-      // If the character right before the selection is a newly inserted
-      // space, we need to advance the selection to maintain the caret position.
-      if (!previousCharASpace && this.value.charAt(start - 1) == ' ')
-        this.$.input.selectionStart++;
-
       if (this.autoValidate)
         this.validate();
+
+      // The cursor automatically jumps to the end after re-setting the value,
+      // so restore it to its original position.
+      this.$.input.selectionStart = start;
+      this.$.input.selectionEnd = start;
+
+      // If the character right before the selection is a newly inserted
+      // space, we need to advance the selection to maintain the caret position.
+      if (!previousCharASpace && this.value.charAt(start - 1) == ' ') {
+        this.$.input.selectionStart = start+1;
+        this.$.input.selectionEnd = start+1;
+      }
     },
 
     validate: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -100,17 +100,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.notEqual(getComputedStyle(error).display, 'none', 'error is not display:none');
       });
 
-      // TODO: re-enable when PolymerElements/iron-input/issues/24 is fixed.
-      // test('caret position is preserved', function() {
-      //   var input = fixture('required');
-      //   var ironInput = input.querySelector('input[is="iron-input"]');
-      //   input.value='1111 1111';
-      //   ironInput.selectionStart = (2,2);
-      //   input.value='1122 1111 11';
-      //
-      //   assert.equal(ironInput.selectionStart, 2, 'selectionStart is preserved');
-      //   assert.equal(ironInput.selectionEnd, 2, 'selectionEnd is preserved');
-      // });
+      test('caret position is preserved', function() {
+        var input = fixture('required');
+        var ironInput = Polymer.dom(input.root).querySelector('input[is="iron-input"]');
+        input.value='1111 1111';
+        ironInput.selectionStart = 2;
+        ironInput.selectionEnd = 2;
+        input._computeValue('1122 1111 11');
+
+        assert.equal(ironInput.selectionStart, 2, 'selectionStart is preserved');
+        assert.equal(ironInput.selectionEnd, 2, 'selectionEnd is preserved');
+      });
 
     });
 


### PR DESCRIPTION
When editing, we reset the element's value to the "formatted" one, which moves the caret to the end. This either preserves the caret position, or advances it to adjust for any bonus spaces entered.

And re-enabled the test! :tada: 