### PR TITLE
Reducing .icon-container height from 27 to 24px

### DIFF
--- a/gold-cc-input.html
+++ b/gold-cc-input.html
@@ -65,7 +65,7 @@ style this element.
     /* Use a container so that when hiding the icon, the layout doesn't jump around. */
     .icon-container {
       margin-left: 10px;
-      height: 27px;
+      height: 24px;
     }
 
     iron-icon {


### PR DESCRIPTION
The .icon-container height style is causing gold-cc-input to display inconsistently with the other input fields of the PolymerElements project. Simple fix.

Please see screen grabs of bug and fix states with chrome dev console open.
https://drive.google.com/folderview?id=0B_0yM-1o-T_jMm9nTG5RWHF0Vmc&usp=sharing

I haven't opened an Issue to track for this bug. I can if needed.