### PR TITLE
fix broken test

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -82,22 +82,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(input.cardType, 'visa');
       });
 
-      test('empty required input shows error on blur', function(done) {
+      test('empty required input shows error on blur', function() {
         var input = fixture('required');
         forceXIfStamp(input);
 
+        var container = Polymer.dom(input.root).querySelector('paper-input-container');
         var error = Polymer.dom(input.root).querySelector('paper-input-error');
         assert.ok(error, 'paper-input-error exists');
-
         assert.equal(getComputedStyle(error).visibility, 'hidden', 'error is visibility:hidden');
+        assert.isFalse(container.invalid);
 
-        input.addEventListener('blur', function(event) {
-          assert(!input.focused, 'input is blurred');
-          assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
-          done();
-        });
         MockInteractions.focus(input);
         MockInteractions.blur(input);
+
+        assert(!input.focused, 'input is blurred');
+        assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
+        assert.isTrue(container.invalid);
       });
 
       test('invalid input shows error message after manual validation', function() {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/gold-cc-input/issues/38.

The test is failing because focusing a `gold-cc-input` needs to focus the inner native `<input>` element, which actually fires a `blur` event (see https://github.com/PolymerElements/paper-input/blob/master/test/paper-input.html#L199 for more details). So if we're listening for blur, that's not great.

We don't actually need to use the event listener at all, and just synchronously check the effect.