### PR TITLE
Mixin to allow customize the icon container

### DIFF
--- a/gold-cc-input.html
+++ b/gold-cc-input.html
@@ -51,6 +51,10 @@ See `Polymer.PaperInputBehavior` for more API docs.
 See `Polymer.PaperInputContainer` for a list of custom properties used to
 style this element.
 
+Custom property | Description | Default 
+----------------|-------------|---------- 
+`----gold-cc-input-icon-container` | Mixin applied to the icon container | `{}`
+
 @group Gold Elements
 @hero hero.svg
 @demo demo/index.html
@@ -70,6 +74,7 @@ style this element.
     .icon-container {
       margin-left: 10px;
       height: 24px;
+      @apply(--gold-cc-input-icon-container);
     }
 
     iron-icon {


### PR DESCRIPTION
The icon inside gold-cc-input element is misplaced when a border is set to the --paper-input-container-input.

This change will allow the developer to customize the icon and not just the Polymer.PaperInputContainer